### PR TITLE
Add options page for configuring admin tab behavior

### DIFF
--- a/chrome/options.html
+++ b/chrome/options.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Luminate Online Page Editor – Options</title>
+  <style>
+    body { font: 14px/1.6 Arial, sans-serif; margin: 24px; max-width: 360px; color: #222; }
+    h1 { font-size: 16px; margin-bottom: 16px; }
+    fieldset { border: 1px solid #ccc; border-radius: 4px; padding: 12px 16px; margin-bottom: 16px; }
+    legend { font-weight: bold; padding: 0 4px; }
+    label { display: block; margin-bottom: 8px; cursor: pointer; }
+    label:last-child { margin-bottom: 0; }
+    input[type="radio"] { margin-right: 6px; }
+    button { padding: 6px 16px; font-size: 14px; cursor: pointer; }
+    #status { margin-left: 10px; font-size: 13px; color: green; }
+  </style>
+</head>
+<body>
+  <h1>Luminate Online Page Editor Options</h1>
+  <form id="options-form">
+    <fieldset>
+      <legend>Open admin page in</legend>
+      <label>
+        <input type="radio" name="openIn" value="new" aria-describedby="new-tab-desc">
+        New tab
+      </label>
+      <label>
+        <input type="radio" name="openIn" value="same" aria-describedby="same-tab-desc">
+        Same tab
+      </label>
+    </fieldset>
+    <button type="submit" id="save-btn">Save</button>
+    <span id="status" role="status" aria-live="polite"></span>
+  </form>
+  <script>
+    var form = document.getElementById('options-form');
+    var status = document.getElementById('status');
+
+    chrome.storage.sync.get({ openIn: 'new' }, function(items) {
+      var radios = form.elements['openIn'];
+      for (var i = 0; i < radios.length; i++) {
+        if (radios[i].value === items.openIn) {
+          radios[i].checked = true;
+          break;
+        }
+      }
+    });
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var selected = form.elements['openIn'].value;
+      chrome.storage.sync.set({ openIn: selected }, function() {
+        status.textContent = 'Saved.';
+        setTimeout(function() { status.textContent = ''; }, 2000);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `chrome/options.html`, a self-contained MV2 options page
- Users can choose whether the page action opens the Luminate admin URL in a **new tab** or the **same tab**
- Setting is persisted via `chrome.storage.sync` (syncs across devices)

## Follow-up required before this is fully functional

- [ ] Add `"options_page": "options.html"` to `chrome/manifest.json`
- [ ] Add `"storage"` to the `"permissions"` array in `chrome/manifest.json`
- [ ] Update `goToEditUrl` in `chrome/src/luminateEdit-chrome.js` to read the `openIn` storage key and branch between `chrome.tabs.create` (new tab) and `chrome.tabs.update` (same tab)

## Test plan

- [ ] Load the unpacked extension in Chrome and verify the options page opens from `chrome://extensions`
- [ ] Toggle the setting, save, and confirm the value persists after reloading the extension
- [ ] Verify clicking the page action opens the admin URL in the correct tab based on the saved setting